### PR TITLE
Add space to error message

### DIFF
--- a/src/Nightshade/Format.hs
+++ b/src/Nightshade/Format.hs
@@ -25,7 +25,7 @@ formatUniforms us
         Sampler2D -> "THREE.Texture | null"
         Int -> "number"
         Float -> "number"
-        t -> error ("Unsupported uniform type" ++ show t)
+        t -> error ("Unsupported uniform type: " ++ show t)
 
 formatShader :: [ Uniform ] -> String -> Doc
 formatShader uniforms src =


### PR DESCRIPTION
Fixes e.g. `Unsupported uniform typeBool` -> `Unsupported uniform type: Bool`